### PR TITLE
Update booking creation to use seat numbers and improve logging

### DIFF
--- a/src/apps/booking/serializers.py
+++ b/src/apps/booking/serializers.py
@@ -1,3 +1,4 @@
+import logging
 from rest_framework import serializers
 from apps.booking.models import Booking
 from apps.trip.models import Trip
@@ -6,7 +7,7 @@ from apps.seat.serializers import SeatSerializer
 from apps.trip.serializers import TripDetailSerializer
 from apps.payment.serializers import PaymentSerializer
 
-
+logger = logging.getLogger(__name__)
 
 class BookingSerializer(serializers.ModelSerializer):
     class Meta:
@@ -29,36 +30,44 @@ class BookingDetailSerializer(serializers.ModelSerializer):
         read_only_fields = ['booking_datetime', 'user', 'total_price']
 
     def create(self, validated_data):
+        logger.debug("Creating new booking")
         trip_id = self.initial_data.get('trip_id')
-        seats_ids = self.initial_data.get('seats_ids', [])
+        seat_numbers = self.initial_data.get('seat_numbers', [])
 
         if not trip_id:
+            logger.error("Trip ID is required")
             raise serializers.ValidationError({"trip_id": "Необходимо указать ID поездки"})
 
-        if not seats_ids:
-            raise serializers.ValidationError({"seats_ids": "Необходимо выбрать хотя бы одно место"})
+        if not seat_numbers:
+            logger.error("seat numbers required")
+            raise serializers.ValidationError({"seat_numbers": "Необходимо выбрать хотя бы одно место"})
 
         trip = Trip.objects.get(pk=trip_id)
         validated_data['trip'] = trip
 
-        trip_seats = TripSeat.objects.filter(trip_id=trip_id, seat_id__in=seats_ids, is_booked=False)
+        trip_seats = TripSeat.objects.filter(trip_id=trip_id, seat__seat_number__in=seat_numbers, is_booked=False)
 
         # Проверяем, что все места доступны
-        if trip_seats.count() != len(seats_ids):
+        if trip_seats.count() != len(seat_numbers):
             # Находим недоступные места
             available_seat_ids = [ts.seat_id for ts in trip_seats]
-            unavailable_ids = [s_id for s_id in seats_ids if s_id not in available_seat_ids]
+            unavailable_ids = [s_id for s_id in seat_numbers if s_id not in available_seat_ids]
+            logger.error("Some seats are not available")
             raise serializers.ValidationError(
-                {"seats_ids": f"Места с ID {', '.join(map(str, unavailable_ids))} недоступны для бронирования"}
+                {"seat_numbers": f"Места с номером {', '.join(map(str, unavailable_ids))} недоступны для бронирования"}
             )
 
         # Создаем бронирование
         booking = Booking.objects.create(**validated_data)
+        logger.info(f"Created new booking: {booking}")
 
         # Бронируем места
+        logger.debug("Booking some seats")
         for trip_seat in trip_seats:
             trip_seat.is_booked = True
             trip_seat.save()
             booking.trip_seats.add(trip_seat)
+            
+        logger.info("Seats successfully booked")
 
         return booking

--- a/src/apps/booking/views.py
+++ b/src/apps/booking/views.py
@@ -56,11 +56,11 @@ class BookingViewSet(viewsets.ModelViewSet):
         operation_summary="Создание бронирования",
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,
-            required=['trip_id', 'seats_ids', 'pickup_location', 'dropoff_location'],
+            required=['trip_id', 'seat_numbers', 'pickup_location', 'dropoff_location'],
             properties={
                 'trip_id': openapi.Schema(type=openapi.TYPE_INTEGER, description='ID поездки'),
-                'seats_ids': openapi.Schema(type=openapi.TYPE_ARRAY, items=openapi.Items(type=openapi.TYPE_INTEGER),
-                                            description='Массив ID мест для бронирования'),
+                'seat_numbers': openapi.Schema(type=openapi.TYPE_ARRAY, items=openapi.Items(type=openapi.TYPE_INTEGER),
+                                            description='Массив номеров мест для бронирования'),
                 'pickup_location': openapi.Schema(type=openapi.TYPE_STRING, description='Адрес посадки'),
                 'dropoff_location': openapi.Schema(type=openapi.TYPE_STRING, description='Адрес высадки')
             }

--- a/src/config/logging.py
+++ b/src/config/logging.py
@@ -3,7 +3,7 @@ LOGGING = {
     'disable_existing_loggers': False,
     'formatters': {
         'verbose': {
-            'format': '{levelname} {asctime} {module} {message}',
+            'format': '{levelname} {asctime} {module}: {message}',
             'style': '{',
         },
     },
@@ -21,7 +21,7 @@ LOGGING = {
         },
         'apps': {
             'handlers': ['console'],
-            'level': 'INFO',
+            'level': 'DEBUG',
             'propagate': True,
         },
         'monitoring': {


### PR DESCRIPTION
Change the booking creation process to require seat numbers instead of IDs, enhancing error handling and logging for better traceability. Update API documentation to reflect this change.