### PR TITLE
Remove push trigger for GitHub Actions and clean up build process

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,6 @@
 name: Build and Test
 
 on:
-  push:
-    branches: [main, develop]
   pull_request:
     branches: [main, develop]
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,23 +33,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Start services
-        run: docker compose up -d
-
-      - name: Wait for services to start
-        run: sleep 10
-
       - name: Create migrations
         run: docker compose exec -T web python src/manage.py makemigrations
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
       - name: Create migrations
         run: docker compose exec -T web python src/manage.py makemigrations
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,21 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Start services
+        run: docker compose up -d
+
+      - name: Wait for services to start
+        run: sleep 10
+
       - name: Create migrations
         run: docker compose exec -T web python src/manage.py makemigrations
 


### PR DESCRIPTION
Eliminate the push trigger from the GitHub Actions workflow and remove unnecessary build steps to streamline the CI process.