### PR TITLE
Update trip permissions for all users

### DIFF
--- a/src/apps/trip/permissions.py
+++ b/src/apps/trip/permissions.py
@@ -4,7 +4,7 @@ from rest_framework import permissions
 class HasTripPermission(permissions.BasePermission):
     """
     Разрешения для поездок:
-    - Просмотр списка поездок и деталей поездки доступен всем аутентифицированным пользователям
+    - Просмотр списка поездок и деталей поездки и мест поездки доступен всем пользователям
     - Создание, изменение и удаление поездок доступно пользователям со специальными правами:
       - can_create_trip - право на создание поездок
       - can_update_trip - право на изменение поездок
@@ -13,15 +13,11 @@ class HasTripPermission(permissions.BasePermission):
     """
 
     def has_permission(self, request, view):
-        # Базовая проверка: пользователь должен быть аутентифицирован
-        if not request.user.is_authenticated:
-            return False
 
         # Администраторы имеют полный доступ
         if request.user.is_superuser:
             return True
 
-        # Для просмотра достаточно аутентификации
         if view.action in ['list', 'retrieve', 'cities', 'seats']:
             return True
 
@@ -41,7 +37,7 @@ class HasTripPermission(permissions.BasePermission):
         if request.user.is_superuser:
             return True
 
-        # Просмотр доступен всем аутентифицированным пользователям
+        # Просмотр доступен всем пользователям
         if view.action in ['retrieve', 'seats']:
             return True
 
@@ -55,3 +51,4 @@ class HasTripPermission(permissions.BasePermission):
 
         # В остальных случаях запрещаем
         return False
+    

--- a/src/apps/trip/tests.py
+++ b/src/apps/trip/tests.py
@@ -390,29 +390,18 @@ class TripPermissionsTest(APITestCase):
         self.assertIn('results', response.data)
 
     def test_list_trips_as_anonymous(self):
-        """Тест запрета получения списка поездок анонимным пользователем"""
+        """Тест возможности получения списка поездок всем пользователем"""
         response = self.client.get(self.trip_list_url)
 
         # Анонимным пользователям требуется аутентификация
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
-    def test_retrieve_trip_as_authenticated(self):
-        """Тест просмотра деталей поездки аутентифицированным пользователем"""
-        # Аутентифицируем пользователя
-        self.client.force_authenticate(user=self.regular_user)
-
-        response = self.client.get(self.trip_detail_url)
-
-        # Аутентифицированные пользователи могут просматривать детали поездки
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['id'], self.trip.id)
 
     def test_retrieve_trip_as_anonymous(self):
-        """Тест запрета просмотра деталей поездки анонимным пользователем"""
+        """Тест возможности просмотра деталей поездки анонимным пользователем"""
         response = self.client.get(self.trip_detail_url)
 
         # Анонимным пользователям требуется аутентификация
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_create_trip_as_anonymous(self):
         """Тест запрета создания поездки анонимным пользователем"""
@@ -579,31 +568,18 @@ class TripPermissionsTest(APITestCase):
         # Проверяем, что поездка действительно удалилась
         self.assertFalse(Trip.objects.filter(id=new_trip.id).exists())
 
-    def test_access_trip_cities_endpoint(self):
-        """Тест доступа к эндпоинту городов аутентифицированными пользователями"""
-        # Проверка для аутентифицированного пользователя
-        self.client.force_authenticate(user=self.regular_user)
-        response = self.client.get(self.trip_cities_url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
     def test_access_trip_cities_endpoint_as_anonymous(self):
-        """Тест запрета доступа к эндпоинту городов анонимным пользователям"""
+        """Тест возможности доступа к эндпоинту городов анонимным пользователям"""
         # Проверка для анонимного пользователя
         response = self.client.get(self.trip_cities_url)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
-    def test_access_seats_endpoint(self):
-        """Тест доступа к эндпоинту мест аутентифицированными пользователями"""
-        # Проверка для аутентифицированного пользователя
-        self.client.force_authenticate(user=self.regular_user)
-        response = self.client.get(self.available_seats_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
 
     def test_access_seats_endpoint_as_anonymous(self):
-        """Тест запрета доступа к эндпоинту мест анонимным пользователям"""
+        """Тест возможности доступа к эндпоинту мест анонимным пользователям"""
         # Проверка для анонимного пользователя
         response = self.client.get(self.available_seats_url)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_role_permissions_consistency(self):
         """Тест последовательности назначения и отзыва прав через группы"""


### PR DESCRIPTION
Allow all users to view trips and trip seat information, removing the requirement for authentication. Update tests to reflect these changes.